### PR TITLE
Remove Makefile.PL from MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,7 +4,6 @@ lib/Pod/POM/Web.pm
 lib/Pod/POM/Web/Help.pod
 lib/Pod/POM/Web/Indexer.pm
 lib/Pod/POM/Web/lib/PodPomWeb.css
-Makefile.PL
 MANIFEST			This list of files
 META.yml
 README


### PR DESCRIPTION
Since this is a `Module::Build` project, a `Makefile.PL` isn't necessary
and including it in the MANIFEST produces unnecessary warnings at build
time.

This PR is submitted in the hope that it is helpful.  If there's anything that needs changing, please just let me know and I'll update and resubmit as necessary.