### PR TITLE
Add META.* files to repo

### DIFF
--- a/META.json
+++ b/META.json
@@ -1,0 +1,69 @@
+{
+   "abstract" : "HTML Perldoc server",
+   "author" : [
+      "Laurent Dami <laurent.d...@justice.ge.ch>"
+   ],
+   "dynamic_config" : 0,
+   "generated_by" : "Module::Build version 0.4224",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "Pod-POM-Web",
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "Test::More" : "0"
+         }
+      },
+      "runtime" : {
+         "recommends" : {
+            "AnnoCPAN::Perldoc::Filter" : "0",
+            "PPI::HTML" : "0",
+            "Search::Indexer" : "0.75"
+         },
+         "requires" : {
+            "Alien::GvaScript" : "1.021",
+            "Config" : "0",
+            "Encode::Guess" : "0",
+            "HTTP::Daemon" : "0",
+            "List::MoreUtils" : "0",
+            "List::Util" : "0",
+            "MIME::Types" : "0",
+            "Module::CoreList" : "0",
+            "Module::Metadata" : "1.000033",
+            "POSIX" : "0",
+            "Pod::POM" : "0.25",
+            "Pod::POM::View::HTML" : "0",
+            "Time::HiRes" : "0",
+            "URI" : "0",
+            "URI::QueryParam" : "0",
+            "parent" : "0"
+         }
+      }
+   },
+   "provides" : {
+      "Pod::POM::Web" : {
+         "file" : "lib/Pod/POM/Web.pm",
+         "version" : "1.23"
+      },
+      "Pod::POM::Web::Indexer" : {
+         "file" : "lib/Pod/POM/Web/Indexer.pm",
+         "version" : "1.23"
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "license" : [
+         "http://dev.perl.org/licenses/"
+      ],
+      "repository" : {
+         "url" : "https://github.com/damil/Pod-POM-Web"
+      }
+   },
+   "version" : "1.23",
+   "x_serialization_backend" : "JSON::PP version 2.27400"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,0 +1,46 @@
+---
+abstract: 'HTML Perldoc server'
+author:
+  - 'Laurent Dami <laurent.d...@justice.ge.ch>'
+build_requires:
+  Test::More: '0'
+dynamic_config: 0
+generated_by: 'Module::Build version 0.4224, CPAN::Meta::Converter version 2.150010'
+license: perl
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: Pod-POM-Web
+provides:
+  Pod::POM::Web:
+    file: lib/Pod/POM/Web.pm
+    version: '1.23'
+  Pod::POM::Web::Indexer:
+    file: lib/Pod/POM/Web/Indexer.pm
+    version: '1.23'
+recommends:
+  AnnoCPAN::Perldoc::Filter: '0'
+  PPI::HTML: '0'
+  Search::Indexer: '0.75'
+requires:
+  Alien::GvaScript: '1.021'
+  Config: '0'
+  Encode::Guess: '0'
+  HTTP::Daemon: '0'
+  List::MoreUtils: '0'
+  List::Util: '0'
+  MIME::Types: '0'
+  Module::CoreList: '0'
+  Module::Metadata: '1.000033'
+  POSIX: '0'
+  Pod::POM: '0.25'
+  Pod::POM::View::HTML: '0'
+  Time::HiRes: '0'
+  URI: '0'
+  URI::QueryParam: '0'
+  parent: '0'
+resources:
+  license: http://dev.perl.org/licenses/
+  repository: https://github.com/damil/Pod-POM-Web
+version: '1.23'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.012'


### PR DESCRIPTION
Although these files are created automatically in the `./Build dist`
step, having them in the repo saves unnecessary warnings from appearing
in the `perl Build.PL` step for testers and potential contributors.

I don't know how controversial a change this is for you, however I thought it might be a useful change for potential contributors and it removes potentially confusing warnings in automated build and test systems.