### PR TITLE
Specify the minimum Perl version explicitly

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,6 +8,7 @@ my $builder = Module::Build->new(
     dist_author         => 'Laurent Dami <laurent.d...@justice.ge.ch>',
     dist_version_from   => 'lib/Pod/POM/Web.pm',
     requires => {
+      'perl'                 => 5.008,
       'parent'               => 0,
       'Alien::GvaScript'     => 1.021000,
       'Pod::POM'             => 0.25,

--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -3,6 +3,7 @@ package Pod::POM::Web; # see doc at end of file
 #======================================================================
 use strict;
 use warnings;
+use 5.008;
 no warnings 'uninitialized';
 
 use Pod::POM 0.25;                  # parsing Pod

--- a/lib/Pod/POM/Web/Indexer.pm
+++ b/lib/Pod/POM/Web/Indexer.pm
@@ -2,6 +2,7 @@ package Pod::POM::Web::Indexer;
 
 use strict;
 use warnings;
+use 5.008;
 no warnings 'uninitialized';
 
 use Pod::POM;


### PR DESCRIPTION
Setting this value helps people looking at the code, CPAN Testers, and
people trying to install the module on an older version of Perl.  The
minimum version requirement was found via the `perlver` tool from the
`Perl::MinimumVersion` distribution.