### PR TITLE
Use three-arg open

### DIFF
--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -1208,7 +1208,7 @@ sub leaf {
 
 sub slurp_file {
   my ($self, $file, $io_layer) = @_;
-  open my $fh, $file or die "open $file: $!";
+  open my $fh, "<", $file or die "open $file: $!";
   binmode($fh, $io_layer) if $io_layer;
   local $/ = undef;
   return <$fh>;


### PR DESCRIPTION
This is currently considered best practice; it is also now consistent
with other open statements in the code.