### PR TITLE
Enable strictures in tests

### DIFF
--- a/t/indexer.t
+++ b/t/indexer.t
@@ -1,5 +1,8 @@
 #!perl
 
+use strict;
+use warnings;
+
 use Test::More tests => 1;
 
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,8 @@
 #!perl -T
 
+use strict;
+use warnings;
+
 use Test::More;
 eval "use Test::Pod 1.14";
 plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;

--- a/t/requests.t
+++ b/t/requests.t
@@ -1,5 +1,8 @@
 #!perl
 
+use strict;
+use warnings;
+
 use Test::More tests => 11;
 use HTTP::Request;
 use HTTP::Response;


### PR DESCRIPTION
This is currently considered best practice, helps to catch simple
errors, and since this only impacts the test files, doesn't have a
negative impact on startup time of the actual application.