### PR TITLE
Minor doc fixes

### DIFF
--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -43,7 +43,7 @@ my $coloring_package
   : eval {require ActiveState::Scineplex} ? "SCINEPLEX" 
   : "";
 
-# fulltext indexing (optional)
+# full-text indexing (optional)
 my $no_indexer = eval {require Pod::POM::Web::Indexer} ? 0 : $@;
 
 # CPAN latest version info (tentative, but disabled because CPAN is too slow)
@@ -1653,7 +1653,7 @@ search through L<perlfaq> headers
 
 =item *
 
-fulltext search, including names of Perl variables
+full-text search, including names of Perl variables
 (this is an optional feature -- see section L</"Optional features">).
 
 =item *

--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -1965,6 +1965,6 @@ under the same terms as Perl itself.
    - exploit doc index X<...>
    - do something with perllocal (installation history)
    - restrict to given set of paths/ modules
-       - ned to change toc (no perlfunc, no scripts/pragmas, etc)
+       - need to change toc (no perlfunc, no scripts/pragmas, etc)
        - treenav with letter entries or not ?
   - port to Plack

--- a/lib/Pod/POM/Web/Help.pod
+++ b/lib/Pod/POM/Web/Help.pod
@@ -66,7 +66,7 @@ with some contextual excerpts of the matching words.
 =head2 Browsing
 
 The browsing tree starts with two sections B<Perl docs> and
-B<Pragmas>, containg core Perl documentation. The third section
+B<Pragmas>, containing core Perl documentation. The third section
 B<Scripts> reflects the structure of Perl scripts installed in 
 C<perl/bin>. The fourth section 
 B<Modules> reflects the structure of installed modules on the local

--- a/lib/Pod/POM/Web/Help.pod
+++ b/lib/Pod/POM/Web/Help.pod
@@ -54,7 +54,7 @@ This only works if the local Perl installation was indexed
 (see L<Pod::POM::Web::Indexer> on how to do it).
 In that case, the input field can contain 
 one or several words, possibly connected
-by boolean operators (L<Search::QueryParser>).
+by Boolean operators (L<Search::QueryParser>).
 The answer will be a list of modules that
 match that query, either in the documentation
 or in the source code. Each module is presented

--- a/lib/Pod/POM/Web/Indexer.pm
+++ b/lib/Pod/POM/Web/Indexer.pm
@@ -426,7 +426,7 @@ __END__
 
 =head1 NAME
 
-Pod::POM::Web::Indexer - fulltext search for Pod::POM::Web
+Pod::POM::Web::Indexer - full-text search for Pod::POM::Web
 
 =head1 SYNOPSIS
 
@@ -434,7 +434,7 @@ Pod::POM::Web::Indexer - fulltext search for Pod::POM::Web
 
 =head1 DESCRIPTION
 
-Adds fulltext search capabilities to the 
+Adds full-text search capabilities to the 
 L<Pod::POM::Web|Pod::POM::Web> application.
 This requires L<Search::Indexer|Search::Indexer> to be installed.
 

--- a/lib/Pod/POM/Web/Indexer.pm
+++ b/lib/Pod/POM/Web/Indexer.pm
@@ -439,7 +439,7 @@ L<Pod::POM::Web|Pod::POM::Web> application.
 This requires L<Search::Indexer|Search::Indexer> to be installed.
 
 Queries may include plain terms, "exact phrases", 
-'+' or '-' prefixes, boolean operators and parentheses.
+'+' or '-' prefixes, Boolean operators and parentheses.
 See L<Search::QueryParser|Search::QueryParser> for details.
 
 


### PR DESCRIPTION
This set of changes fixes some minor typos and spelling issues which were noted while looking over the text.  They've been split into separate commits so as to be cherry picked if a particular change is unwanted.