### PR TITLE
Add missing prereqs

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -10,6 +10,7 @@ my $builder = Module::Build->new(
     requires => {
       'parent'               => 0,
       'Alien::GvaScript'     => 1.021000,
+      'BerkeleyDB'           => 0,
       'Pod::POM'             => 0.25,
       'Pod::POM::View::HTML' => 0,
       'List::Util'           => 0,

--- a/Build.PL
+++ b/Build.PL
@@ -32,7 +32,9 @@ my $builder = Module::Build->new(
       'AnnoCPAN::Perldoc::Filter' => 0,
     },
     build_requires => {
-      'Test::More' => 0,
+      'Test::More'     => 0,
+      'HTTP::Request'  => 0,
+      'HTTP::Response' => 0,
     },
     add_to_cleanup      => [ 'Pod-POM-Web-*' ],
     meta_merge => {


### PR DESCRIPTION
The missing dependencies were found by using `Test::Kwalitee::Extra`.  This tool also found that `Apache2::Response` was missing, however it was decided not to add this as a dependency as it implies that `mod_perl` also needs to be installed, and in order for `mod_perl` to be installed and tested, one needs to install Apache as well.  This seemed too big a hurdle for users simply wanting to install and use the module, so it was left out.  Also, the use of `Apache2::Response` is conditional on its availablity and a set up `mod_perl` environment, so it doesn't need to be added as a prerequisite.