### PR TITLE
Make server start message clearer

### DIFF
--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -100,7 +100,7 @@ sub server { # builtin HTTP server; unused if running under Apache
   my $daemon = HTTP::Daemon->new(LocalPort => $port,
                                  ReuseAddr => 1) # patch by CDOLAN
     or die "could not start daemon on port $port";
-  print STDERR "Please contact me at: <URL:", $daemon->url, ">\n";
+  print STDERR "Server started at: <URL:", $daemon->url, ">\n";
 
   # main server loop
   while (my $client_connection = $daemon->accept) {


### PR DESCRIPTION
The phrase "Please contact me" sounds like one should send an email (or
similar) to someone, whereas what is meant is that the server has
started at the given address.  This change should improve the clarity of
the message.

By the way: why does the server start message need to be printed to STDERR?  It seems like the wrong place, since it's not an error that's occuring; the message seems to be purely informative.  Would you like me to perhaps change the `print` to output to simply `STDOUT`?