### PR TITLE
Add tests to Pod::POM::Web

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -35,6 +35,7 @@ my $builder = Module::Build->new(
       'Test::More'     => 0,
       'HTTP::Request'  => 0,
       'HTTP::Response' => 0,
+      'Capture::Tiny'  => 0,
     },
     add_to_cleanup      => [ 'Pod-POM-Web-*' ],
     meta_merge => {

--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -440,7 +440,7 @@ sub serve_script {
     }
   }
 
-  $fullpath or die "no such script : $path";
+  $fullpath and -e $fullpath or die "no such script : $path";
 
   my $content = $self->slurp_file($fullpath, ":crlf");
   my $mtime   = (stat $fullpath)[9];

--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -432,7 +432,7 @@ sub serve_script {
 
   my $fullpath;
 
- DIR:
+  DIR:
   foreach my $dir (@script_dirs) {
     foreach my $ext ("", ".pl", ".bat") {
       $fullpath = "$dir/$path$ext";

--- a/lib/Pod/POM/Web.pm
+++ b/lib/Pod/POM/Web.pm
@@ -92,12 +92,14 @@ sub import {
 #----------------------------------------------------------------------
 
 sub server { # builtin HTTP server; unused if running under Apache
-  my ($class, $port, $options) = @_;
+  my ($class, $port, $timeout, $options) = @_;
 
   $options ||= $class->_options_from_cmd_line;
   $port    ||= $options->{port} || 8080;
+  $timeout ||= $options->{timeout};
 
   my $daemon = HTTP::Daemon->new(LocalPort => $port,
+                                 Timeout => $timeout,
                                  ReuseAddr => 1) # patch by CDOLAN
     or die "could not start daemon on port $port";
   print STDERR "Please contact me at: <URL:", $daemon->url, ">\n";

--- a/t/requests.t
+++ b/t/requests.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 12;
+use Test::More tests => 13;
 use HTTP::Request;
 use HTTP::Response;
 use Module::Metadata;
@@ -57,6 +57,24 @@ $regex   .= '\(v.\s*' . $http_req_version if $http_req_version;
 
 # now the actual test
 response_like("/HTTP/Request",  qr/$regex/, "serve_pod");
+
+subtest "perlvar" => sub {
+    plan tests => 2;
+
+    my $ppw = Pod::POM::Web->new();
+    my $html = capture_stdout {
+        $ppw->perlvar('unable_to_be_found_perl_var');
+    };
+
+    like($html, qr/No documentation found/, "Unknown perlvar search term returns no answers");
+
+    $html = capture_stdout {
+        $ppw->perlvar('@INC');
+    };
+
+    like($html, qr/Extract\s+from\s+.*?perlvar/, "Known perlvar search term returns entry");
+};
+
 
 subtest "perlfaq" => sub {
     plan tests => 2;

--- a/t/requests.t
+++ b/t/requests.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 16;
+use Test::More tests => 17;
 use HTTP::Request;
 use HTTP::Response;
 use Module::Metadata;
@@ -57,6 +57,13 @@ $regex   .= '\(v.\s*' . $http_req_version if $http_req_version;
 
 # now the actual test
 response_like("/HTTP/Request",  qr/$regex/, "serve_pod");
+
+subtest "module not found" => sub {
+    plan tests => 1;
+    response_like("/_no_such_module", qr/_no_such_module not found/,
+                  "See expected error message with unknown module");
+};
+
 
 subtest "fake perltoc" => sub {
     plan tests => 1;

--- a/t/requests.t
+++ b/t/requests.t
@@ -3,11 +3,11 @@
 use strict;
 use warnings;
 
-use Test::More tests => 17;
+use Test::More tests => 18;
 use HTTP::Request;
 use HTTP::Response;
 use Module::Metadata;
-use Capture::Tiny qw(capture_stdout);
+use Capture::Tiny qw(capture_stdout capture_stderr);
 
 
 BEGIN {
@@ -57,6 +57,17 @@ $regex   .= '\(v.\s*' . $http_req_version if $http_req_version;
 
 # now the actual test
 response_like("/HTTP/Request",  qr/$regex/, "serve_pod");
+
+
+subtest "builtin server" => sub {
+    plan tests => 1;
+    my $ppw = Pod::POM::Web->new();
+    my $output = capture_stderr {
+        $ppw->server(8888, 1);
+    };
+    like($output, qr{Please contact me at: <URL:http://.*?:8888/>}, "Expected server startup message");
+};
+
 
 subtest "module not found" => sub {
     plan tests => 1;

--- a/t/requests.t
+++ b/t/requests.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
+use Test::More tests => 14;
 use HTTP::Request;
 use HTTP::Response;
 use Module::Metadata;
@@ -57,6 +57,27 @@ $regex   .= '\(v.\s*' . $http_req_version if $http_req_version;
 
 # now the actual test
 response_like("/HTTP/Request",  qr/$regex/, "serve_pod");
+
+subtest "TOC for perldocs, pragmas etc." => sub {
+    plan tests => 3;
+
+    my $ppw = Pod::POM::Web->new();
+    my $html = capture_stdout {
+        $ppw->toc_for('perldocs');
+    };
+    like($html, qr/perlintro/, "Perl intro included in perldocs TOC info");
+
+    $html = capture_stdout {
+        $ppw->toc_for('pragmas');
+    };
+    like($html, qr/href='strict'/, "strict pragma included in pragmas TOC info");
+
+    $html = capture_stdout {
+        $ppw->toc_for('scripts');
+    };
+    like($html, qr/href='script\/perlbug'/, "perlbug script included in scripts TOC info");
+};
+
 
 subtest "perlvar" => sub {
     plan tests => 2;

--- a/t/requests.t
+++ b/t/requests.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 15;
+use Test::More tests => 16;
 use HTTP::Request;
 use HTTP::Response;
 use Module::Metadata;
@@ -57,6 +57,14 @@ $regex   .= '\(v.\s*' . $http_req_version if $http_req_version;
 
 # now the actual test
 response_like("/HTTP/Request",  qr/$regex/, "serve_pod");
+
+subtest "fake perltoc" => sub {
+    plan tests => 1;
+    my $ppw = Pod::POM::Web->new();
+    my $html = $ppw->fake_perltoc();
+    like($html, qr/Sorry, this page cannot be displayed/, "Found expected fake perltoc message");
+};
+
 
 subtest "serve script" => sub {
     plan tests => 3;


### PR DESCRIPTION
This PR extends the test suite to test more of the functionality in the `Pod::POM::Web` module.  It increases test coverage in this module to 90%.  I've split the PR up into several commits so that they can be cherry picked as required.  Hopefully this helps with documenting current behaviour and with future refactoring.

I've put the tests into the `t/requests.t` file, which might not be the best place for them, so if you would like them to be put somewhere else, please just let me know and I'll restructure and resubmit the PR.