### PR TITLE
Display cpanm build log on Travis build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ perl:
 
 install:
     - sudo apt-get install libdb-dev
-    - cpanm --installdeps .
-    - cpanm --with-recommends .
+    - cpanm --installdeps . || { cat ~/.cpanm/build.log ; false ; }
+    - cpanm --with-recommends . || { cat ~/.cpanm/build.log ; false ; }
     - wget http://annocpan.org/annopod.db -O ~/.annopod.db


### PR DESCRIPTION
Sometimes installing dependencies can fail on Travis and one loses the information contained in `cpanm`'s `build.log` file.  This patch displays the log output if the build fails so that Travis builds can be more easily debugged.