### PR TITLE
Extend Pod::POM::Web::indexer tests

### DIFF
--- a/lib/Pod/POM/Web/Indexer.pm
+++ b/lib/Pod/POM/Web/Indexer.pm
@@ -81,6 +81,15 @@ my @stopwords = (
 );
 
 
+sub new {
+    my ($class, $request, $response, $options) = @_;
+
+    my $self = $class->SUPER::new($request, $response, $options);
+
+    return $self;
+}
+
+
 #----------------------------------------------------------------------
 # RETRIEVING
 #----------------------------------------------------------------------

--- a/lib/Pod/POM/Web/Indexer.pm
+++ b/lib/Pod/POM/Web/Indexer.pm
@@ -28,8 +28,6 @@ my $ignore_headings = qr[
       SYNOPSIS | DESCRIPTION | METHODS   | FUNCTIONS |
       BUGS     | AUTHOR      | SEE\ ALSO | COPYRIGHT | LICENSE ]x;
 
-(my $index_dir = __FILE__) =~ s[Indexer\.pm$][index];
-
 my $id_regex = qr/(?![0-9])       # don't start with a digit
                   \w\w+           # start with 2 or more word chars ..
                   (?:::\w+)*      # .. and  possibly ::some::more::components
@@ -85,6 +83,7 @@ sub new {
     my ($class, $request, $response, $options) = @_;
 
     my $self = $class->SUPER::new($request, $response, $options);
+    ($self->{index_dir} = __FILE__) =~ s[Indexer\.pm$][index];
 
     return $self;
 }
@@ -99,7 +98,7 @@ sub full_text {
   my ($self, $search_string) = @_;
 
   my $indexer = eval {
-    new Search::Indexer(dir       => $index_dir,
+    new Search::Indexer(dir       => $self->{index_dir},
                         wregex    => $wregex,
                         preMatch  => '[[',
                         postMatch => ']]');
@@ -271,6 +270,7 @@ sub index {
     if grep {!/^-(from_scratch|max_size|positions)$/} keys %options;
 
   # make sure index dir exists
+  my $index_dir = $self->{index_dir};
   -d $index_dir or mkdir $index_dir or die "mkdir $index_dir: $!";
 
   # if -from_scratch, throw away old index
@@ -413,6 +413,7 @@ sub index_file {
 sub _tie_docs {
   my ($self, $mode) = @_;
 
+  my $index_dir = $self->{index_dir};
   # tie to docs.bdb, storing {$doc_id => "$mtime\t$pathname\t$description"}
   tie %{$self->{_docs}}, 'BerkeleyDB::Hash',
       -Filename => "$index_dir/docs.bdb",

--- a/t/indexer.t
+++ b/t/indexer.t
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 
 use Test::More;
+use Capture::Tiny qw(capture_stderr);
+use File::Temp qw(tempdir);
 
 BEGIN {
     eval {require Search::Indexer};
@@ -11,9 +13,26 @@ BEGIN {
       if $@;
 }
 
-plan tests => 2;
+plan tests => 3;
 
 use_ok( 'Pod::POM::Web::Indexer' );
+
+subtest "indexing" => sub {
+    plan tests => 2;
+
+    my $ppwi = Pod::POM::Web::Indexer->new();
+
+    $ppwi->{index_dir} = tempdir(CLEANUP => 1);
+    my $output = capture_stderr {
+        $ppwi->index();
+    };
+    like($output, qr/INDEXING/, "Creating index creates individual indices");
+
+    $output = capture_stderr {
+        $ppwi->index();
+    };
+    unlike($output, qr/INDEXING/, "Rerunning index avoids recreation");
+};
 
 subtest "uri escape" => sub {
     plan tests => 3;

--- a/t/indexer.t
+++ b/t/indexer.t
@@ -3,15 +3,16 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More;
 
-
-SKIP: {
-  eval {require Search::Indexer};
-  skip "Search::Indexer does not seem to be installed", 1
-    if $@;
-  use_ok( 'Pod::POM::Web::Indexer' );
+BEGIN {
+    eval {require Search::Indexer};
+    plan skip_all => 'Search::Indexer does not seem to be installed'
+      if $@;
 }
 
+plan tests => 1;
+
+use_ok( 'Pod::POM::Web::Indexer' );
 
 # TODO ... more than just a compile test

--- a/t/indexer.t
+++ b/t/indexer.t
@@ -11,8 +11,25 @@ BEGIN {
       if $@;
 }
 
-plan tests => 1;
+plan tests => 2;
 
 use_ok( 'Pod::POM::Web::Indexer' );
+
+subtest "uri escape" => sub {
+    plan tests => 3;
+    is(uri_escape(), undef, "An escaped, undefined URI stays undefined");
+
+    my $plain_uri = "http://example.com";
+    is(uri_escape($plain_uri), $plain_uri, "Plain URI remains unchanged");
+
+    my $unescaped_uri = "http://example.com/^;/?:\@,Az0-_.!~*'()";
+    my $escaped_uri = "http://example.com/%5E;/?:\@,Az0-_.!~*'()";
+    is(uri_escape($unescaped_uri), $escaped_uri, "Non-standard characters escaped in URI");
+};
+
+sub uri_escape {
+    my $uri = shift;
+    return Pod::POM::Web::Indexer::uri_escape($uri);
+}
 
 # TODO ... more than just a compile test


### PR DESCRIPTION
These changes increase the code coverage of the `Pod::POM::Web::Indexer` tests to roughly 70%.  This figure is a bit misleading, since the tests themselves are very coarse-grained and require the index to be built at least twice; hence the tests take a minute or two to run.  Although this sounds like a bad thing, the increased test coverage means one can be more confident in refactoring the codebase and hence the tests can become more focused over time and thus faster again.  It might be a good idea to skip some of the tests using the indexing operations on slow hardware; if you want I could add something like a `SLOW_TESTS` environment variable and then only when this is set will the slow tests be run.

Anyway, hope these changes help in some way!